### PR TITLE
fix(provider): allow config not to be required when instance used

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -25,8 +25,26 @@ export function getRollbarConstructorFromContext(context) {
 export class Provider extends Component {
   static propTypes = {
     Rollbar: PropTypes.func,
-    config: PropTypes.oneOfType([PropTypes.object, PropTypes.func]).isRequired,
-    instance: PropTypes.instanceOf(Rollbar),
+    config: (props, propName, componentName) => {
+      if (!props.config && !props.instance) {
+        return new Error(`One of the required props 'config' or 'instance' must be set for ${componentName}.`)
+      }
+      if (props.config) {
+        const configType = typeof props.config;
+        if (configType === 'function' || configType === 'object' && !Array.isArray(configType)) {
+          return;
+        }
+        return new Error(`${propName} must be either an Object or a Function`);
+      }
+    },
+    instance: (props, propName, componentName) => {
+      if (!props.config && !props.instance) {
+        return new Error(`One of the required props 'config' or 'instance' must be set for ${componentName}.`)
+      }
+      if (props.instance && !(props.instance instanceof Rollbar)) {
+        return new Error(`${propName} must be an instance of Rollbar`);
+      }
+    }
   }
 
   constructor(props) {


### PR DESCRIPTION
## Description of the change

> API documentation states that either a `config` prop with a Rollbar configuration as a hash can be passed to the `Provider` or an `instance` prop which is a constructed instance of Rollbar. When the `instance` prop is being used, the `Provider` is complaining that the required `config` prop is not being set per the prop types definitions.

This PR fixes this issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Fix #8
