### PR TITLE
fix: bugs related to fallbackUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,7 @@ export function App(props) {
 You may also include a Fallback UI to render when the error occurs so that the User does not experience a broken/blank
 UI caused during the render cycle of React.
 
-Like the other `prop`s it can accept a value that is a React Component or a function that returns a React Component with
-the same signature `(error, info)`.
+It can accept a value that is a React Component
 
 ```javascript
 import React from 'react';
@@ -280,7 +279,10 @@ const rollbarConfig = {
 };
 
 const ErrorDisplay = ({ error, resetError }) => ( // <-- props passed to fallbackUI component
-  <div>…</div>
+  <div>
+    <h1>A following error has occured:</h1>
+    <p>{error.toString()}</p>
+  </div>
 );
 
 export function App(props) {

--- a/examples/index.js
+++ b/examples/index.js
@@ -4,15 +4,16 @@ import { Router, Switch, Route } from 'react-router-dom';
 import { Client } from 'rollbar-react-native';
 import { Provider, Context, ErrorBoundary, useRollbar, useRollbarCaptureEvent, LEVEL_INFO, useRollbarPerson, useContext, RollbarContext, historyContext } from '../src';
 
-const ErrorDisplay = ({ error, resetError }) => ( // <-- props passed to fallbackUI component
-  <div>…</div>
-);
-
-function displayForError(error, resetError) { // <-- args passed to fallbackUI function
+function ErrorDisplay({error, resetError}) { // <-- props passed to fallbackUI component
   if (error instanceof AggregateError) {
     return <AggregateDisplay error={error} />;
   }
-  return <ErrorDisplay error={error} onclick={resetError} />;
+  return (
+    <div>
+      <h1>Something went wrong.</h1>
+      {error && <p>{error.toString()}</p>}
+    </div>
+  );
 }
 
 const rollbarConfig = {

--- a/src/error-boundary.js
+++ b/src/error-boundary.js
@@ -52,25 +52,16 @@ export class ErrorBoundary extends Component {
 
   render() {
     const { hasError, error } = this.state;
-    const { fallbackUI, children } = this.props;
+    const { fallbackUI: FallbackUI, children } = this.props;
 
     if (!hasError) {
       return children;
     }
 
-    if (!fallbackUI) {
+    if (!FallbackUI) {
       return null;
     }
 
-    if (React.isValidElement(fallbackUI)) {
-      return <fallbackUI error={error} resetError={this.resetError} />;
-    }
-
-    if (typeof fallbackUI === 'function') {
-      const fallbackComponent = fallbackUI(error, this.resetError);
-      return React.isValidElement(fallbackComponent) ? fallbackComponent : null;
-    }
-
-    return null;
+    return <FallbackUI error={error} resetError={this.resetError} />;
   }
 }


### PR DESCRIPTION
## Description of the change

This PR fixes some bugs related to `fallbackUI`
1. It was possible to pass a rendered element like this:
```javascript
<ErrorBoundary level={LEVEL_WARN} fallbackUI={<FallbackComponent />}>
```
which would cause an error ( issue #19 ) caused by this line of code:
https://github.com/rollbar/rollbar-react/blob/main/src/error-boundary.js#L66
I think there was a misunderstanding of `React.isValidElement()`. It checks if a thing passed to it is an element (a result of rendering a component) not a component (function or a class with `render` method). `<FallbackComponent />` passes `React.isValidElement()` but the line mentioned above tries to render it again, hence the error. What is more react doesn't like lowercase names for components, also used in line 66. I think an option of passing already rendered element doesn't bring any benefit over passing a functional component. Such an option wasn't also mentioned in the docs.

2. It was not possible to properly pass a regular react component as fallbackUI as the docs suggested.
- a functional react component which takes an object with props as its keys: `const FallbackComponent = ({error, resetError}) => <div>error</div>`
- a class component also wouldn't work properly
The problem was that both those things are of a type `function` and would go through this line:
https://github.com/rollbar/rollbar-react/blob/main/src/error-boundary.js#L70
It would pass the props as positional arguments, not as a props object, resulting with a component with a regular signature `({error, resetError})` destructuring both the props as `undefined`.
The generator function also mentioned in the docs worked, but that's practically the same as a functional component. The difference is that a component takes params in an object `({error, resetError})` when a generator mentioned in the docs skips the object part `(error, resetError)`. After the changes users will also be able to use class components as fallbackUI.
WARNING: Dropping the option of passing a generator function is a breaking change.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #19 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
