### PR TITLE
Provider declaration typos

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,13 +42,13 @@ export class RollbarContext extends Component<{
 
 export interface ProviderProps {
   Rollbar?: new (options: Configuration) => Rollbar;
-  config?: Configuration | (() => Configuation);
+  config?: Configuration | (() => Configuration);
   instance?: Rollbar;
 }
 
 interface ProviderState {
   rollbar: Rollbar;
-  options: Coniguration;
+  options: Configuration;
 }
 
 export class Provider extends Component<ProviderProps, ProviderState> {}


### PR DESCRIPTION
## Description of the change

Fixes typos in Provider declaration. Based on testing: These typos don't cause the typescript build to fail. Rather, they prevent type checking, and allow wrongly typed props to silently succeed.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
