### PR TITLE
Allow rollbar instance from alternate import/require

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Rollbar from 'rollbar';
 import invariant from 'tiny-invariant';
 import * as constants from './constants';
-import * as utils from './utils';
+import { isRollbarInstance } from './utils';
 
 export const Context = createContext();
 Context.displayName = 'Rollbar';
@@ -41,8 +41,8 @@ export class Provider extends Component {
       if (!props.config && !props.instance) {
         return new Error(`One of the required props 'config' or 'instance' must be set for ${componentName}.`)
       }
-      if (props.instance && !(props.instance instanceof Rollbar)) {
-        return new Error(`${propName} must be an instance of Rollbar`);
+      if (props.instance && !isRollbarInstance(props.instance)) {
+        return new Error(`${propName} must be a configured instance of Rollbar`);
       }
     }
   }
@@ -50,7 +50,10 @@ export class Provider extends Component {
   constructor(props) {
     super(props);
     const { config, Rollbar: ctor = Rollbar, instance } = this.props;
-    invariant(!instance || instance instanceof Rollbar, 'providing `instance` must be of type Rollbar');
+    invariant(
+      !instance || isRollbarInstance(instance),
+      '`instance` must be a configured instance of Rollbar'
+    );
     const options = typeof config === 'function' ? config() : config;
     const rollbar = instance || new ctor(options);
     // TODO: use isUncaught to filter if this is 2nd Provider added

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,3 +17,7 @@ export function isValidLevel(level) {
   return VALID_LEVELS[level] >= VALID_LEVELS[constants.LEVEL_DEBUG]
     && VALID_LEVELS[level] <= VALID_LEVELS[constants.LEVEL_CRITICAL];
 }
+
+export function isRollbarInstance(instance) {
+  return !!instance?.options?.accessToken;
+}


### PR DESCRIPTION
## Description of the change

The Provider validates the Rollbar instance, when one is in the props, by testing `instanceof` the default `Rollbar` import. This fails when the instance was constructed from another import or require. The specific issue report involves using the noconflict bundle.

This PR looks for an initialized options object instead. This will successfully catch common errors like passing the constructor function or failing to initialize before passing the instance.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes https://github.com/rollbar/rollbar-react/issues/24

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
