### PR TITLE
Export provider context for class components to use

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
-import { Component, ReactNode } from "react";
+import { Component, Context as ReactContext, ReactNode } from "react";
 import Rollbar, { Callback, Configuration } from "rollbar";
+import { RollbarInstance, BaseOptions, RollbarCtor } from "./src/provider";
 
 export const LEVEL_DEBUG = "debug";
 export const LEVEL_INFO = "info";
@@ -53,6 +54,15 @@ interface ProviderState {
 
 export class Provider extends Component<ProviderProps, ProviderState> {}
 
+interface ContextInterface {
+  [RollbarInstance]: Rollbar;
+  [BaseOptions]: Configuration;
+  [RollbarCtor]: new (options: Configuration) => Rollbar;
+}
+
+export const Context: ReactContext<ContextInterface>;
+
+export function getRollbarFromContext(context: Context): Rollbar;
 export function useRollbar(): Rollbar;
 export function useRollbarConfiguration(config: Rollbar.Configuration): void;
 export function useRollbarContext(ctx?: string, isLayout?: boolean): void;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 export { LEVEL_DEBUG, LEVEL_INFO, LEVEL_WARN, LEVEL_ERROR, LEVEL_CRITICAL } from './constants';
 export { historyContext } from './history-context';
-export { Provider } from './provider';
+export { Provider, Context, getRollbarFromContext } from './provider';
 export { ErrorBoundary } from './error-boundary';
 export { RollbarContext } from './rollbar-context';
 export { isValidLevel } from './utils';

--- a/src/provider.js
+++ b/src/provider.js
@@ -8,9 +8,9 @@ import * as utils from './utils';
 export const Context = createContext();
 Context.displayName = 'Rollbar';
 
-const RollbarInstance = Symbol('RollbarInstance');
-const BaseOptions = Symbol('BaseOptions');
-const RollbarCtor = Symbol('RollbarCtor');
+export const RollbarInstance = Symbol('RollbarInstance');
+export const BaseOptions = Symbol('BaseOptions');
+export const RollbarCtor = Symbol('RollbarCtor');
 
 export function getRollbarFromContext(context) {
   const { [RollbarInstance]: rollbar } = context;


### PR DESCRIPTION
## Description of the change

Rollbar-react uses a React Context to make the Rollbar object available to all components. Function components can use the `useRollbar` hook, and this is the easiest way to get the Rollbar object.

Class components cannot use hooks, and so cannot use the `useRollbar` hook. React provides other ways to get the context, but the package currently lacks the necessary exports.

This PR adds the exports that allow class components to get the Rollbar object from the React Context, and adds the related type definitions so this will also work in Typescript.

Usage examples have been added to the related issue: https://github.com/rollbar/rollbar-react/issues/17

## Type of change

- [x] New feature (non-breaking change that adds functionality)


## Related issues

Fixes https://github.com/rollbar/rollbar-react/issues/17

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
