### PR TITLE
ErrorBoundary.fallbackUI can't be a node

### DIFF
--- a/src/error-boundary.js
+++ b/src/error-boundary.js
@@ -11,7 +11,7 @@ export class ErrorBoundary extends Component {
   static contextType = Context;
 
   static propTypes = {
-    fallbackUI: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+    fallbackUI: PropTypes.func,
     errorMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     extra: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     level: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),


### PR DESCRIPTION
## Description of the change

The `ErrorBoundary` component's `propTypes` field says that it can be a react node or a function. However, if passed a node (e.g. `<p>oops</p>`), you get the following error:

```
Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.

Check the render method of `ErrorBoundary`.
```

This PR simply removes the `PropTypes.node` reference from the definition.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Changes have been reviewed by at least one other engineer
