### PR TITLE
Let propType errors cause test failure

### DIFF
--- a/src/tests/jest-setup.ts
+++ b/src/tests/jest-setup.ts
@@ -1,2 +1,9 @@
 import '@testing-library/jest-dom';
 import 'regenerator-runtime';
+
+// Let propType errors cause test failure.
+const originalConsoleError = console.error;
+console.error = (message: string) => {
+  if (/(Failed prop type)/.test(message)) throw new Error(message);
+  originalConsoleError(message);
+};


### PR DESCRIPTION
## Description of the change

This came up while testing https://github.com/rollbar/rollbar-react/pull/46. I noticed the propTypes failures weren't causing a test failure. (propTypes errors only generate a console.error; they don't throw.) This PR fixes that globally for all components under test.

## Type of change

- [x] Maintenance: Test

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
