### PR TITLE
Fix main branch name to run CI on PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ '**' ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
## Description of the change

I noticed CI didn't trigger on https://github.com/rollbar/rollbar-react/pull/46, and this seems to be caused by a wrong branch name for the main branch. Non-forked branch PRs did run CI, since the push branches rule still worked for those. This problem only became apparent with forked branches that rely on the pull_request branches rule.

## Type of change

- [x] Maintenance: CI


### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
