### PR TITLE
Fix declaration of unique symbols

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
 import { Component, Context as ReactContext, ReactNode } from 'react';
 import Rollbar, { Callback, Configuration } from 'rollbar';
-import { RollbarInstance, BaseOptions, RollbarCtor } from './src/provider';
 
 export const LEVEL_DEBUG = 'debug';
 export const LEVEL_INFO = 'info';
@@ -54,6 +53,10 @@ interface ProviderState {
 
 export class Provider extends Component<ProviderProps, ProviderState> {}
 
+declare const RollbarInstance: unique symbol;
+declare const BaseOptions: unique symbol;
+declare const RollbarCtor: unique symbol;
+
 interface ContextInterface {
   [RollbarInstance]: Rollbar;
   [BaseOptions]: Configuration;
@@ -62,7 +65,7 @@ interface ContextInterface {
 
 export const Context: ReactContext<ContextInterface>;
 
-export function getRollbarFromContext(context: Context): Rollbar;
+export function getRollbarFromContext(context: ReactContext<ContextInterface>): Rollbar;
 export function useRollbar(): Rollbar;
 export function useRollbarConfiguration(config: Rollbar.Configuration): void;
 export function useRollbarContext(ctx?: string, isLayout?: boolean): void;


### PR DESCRIPTION
## Description of the change

The Typescript declaration file was importing several unique symbols (`RollbarInstance, BaseOptions, RollbarCtor`) to be used in a type definition, but the path for these doesn't exist in the release package, breaking the import path.

To fix this, the import can be removed completely since only a declaration of a unique symbol is needed, not the actual value.

This PR also fixes an issue where a constant (`Context`) was used instead of the correct type (`ReactContext<ContextInterface>`).

Note: "unexpected any" CI warnings are expected, and not related to the PR.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes: https://github.com/rollbar/rollbar-react/issues/48

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
