### PR TITLE
Add children to the props for @types/react@18

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,7 @@ export class RollbarContext extends Component<{
 
 export interface ProviderProps {
   Rollbar?: new (options: Configuration) => Rollbar;
+  children: ReactNode;
   config?: Configuration | (() => Configuration);
   instance?: Rollbar;
 }


### PR DESCRIPTION
In relation to React props should not do anything special with children and DefinitelyTyped have updated the react types to v18

https://github.com/DefinitelyTyped/DefinitelyTyped/issues/59802