### PR TITLE
Fix for ErrorBoundary extra prop type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Component, Context as ReactContext, ReactNode } from 'react';
+import { Component, Context as ReactContext, ErrorInfo, ReactNode } from 'react';
 import Rollbar, { Callback, Configuration } from 'rollbar';
 
 export const LEVEL_DEBUG = 'debug';
@@ -13,13 +13,14 @@ export type LEVEL =
   | typeof LEVEL_ERROR
   | typeof LEVEL_CRITICAL;
 
+type Extra = Record<string | number, unknown>;
 export interface ErrorBoundaryProps {
   children: ReactNode;
   fallbackUI?: ReactNode;
   errorMessage?: string | (() => string);
   extra?:
-    | Record<string | number, unknown>
-    | (() => Record<string | number, unknown>);
+    | Extra
+    | ((error: Error, errorInfo: ErrorInfo) => Extra);
   level?: LEVEL | (() => LEVEL);
   callback?: Callback<any>;
 }

--- a/src/tests/components/error-boundary.test.tsx
+++ b/src/tests/components/error-boundary.test.tsx
@@ -59,4 +59,30 @@ describe('ErrorBoundary', () => {
       errorMessage, error, expect.objectContaining(extra), callback
     );
   });
+
+  describe('with extra prop as a fn', () => {
+    it('should send extra value to rollbar on error', () => {
+      const extraFn: ErrorBoundaryProps['extra'] = (error, errorInfo) => {
+        expect(error).toBeInstanceOf(Error)
+        expect(errorInfo).toHaveProperty('componentStack')
+        return extra;
+      };
+  
+      renderWithProviderProps(
+        <TestComponent
+          fallbackUI={Fallback}
+          errorMessage={errorMessage}
+          extra={extraFn}
+          level={level}
+          callback={callback}
+        />,
+        {},
+        {config: config}
+      );
+  
+      expect(rollbar.warn).toHaveBeenLastCalledWith(
+        errorMessage, error, expect.objectContaining(extra), callback
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Description of the change

This PR fixes the type definition of the `extra` prop from the `ErrorBoundary` component.
When `extra` prop is a function, the correct signature should include `(error, info)` as an argument as described [here](https://github.com/rollbar/rollbar-react#pass-props-to-control-behavior).
> These props take either a value or a function that will be invoked with the error and info from the [Error Boundaries](https://reactjs.org/docs/error-boundaries.html) API's componentDidCatch method (i.e. signature is (error, info)).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
