### PR TITLE
fix ErrorBoundary fallbackUI prop type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,10 @@ export type LEVEL =
 type Extra = Record<string | number, unknown>;
 export interface ErrorBoundaryProps {
   children: ReactNode;
-  fallbackUI?: ReactNode;
+  fallbackUI?: (props: {
+    error: Error | null;
+    resetError: () => void;
+  }) => ReactNode;
   errorMessage?: string | (() => string);
   extra?:
     | Extra

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Component, Context as ReactContext, ErrorInfo, ReactNode } from 'react';
+import { Component, Context as ReactContext, ErrorInfo, ReactNode, ComponentType } from 'react';
 import Rollbar, { Callback, Configuration } from 'rollbar';
 
 export const LEVEL_DEBUG = 'debug';
@@ -16,7 +16,7 @@ export type LEVEL =
 type Extra = Record<string | number, unknown>;
 export interface ErrorBoundaryProps {
   children: ReactNode;
-  fallbackUI?: React.ComponentType<{ error: Error | null, resetError: () => void }>;
+  fallbackUI?: ComponentType<{ error: Error | null, resetError: () => void }>;
   errorMessage?: string | (() => string);
   extra?:
     | Extra

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,10 +16,7 @@ export type LEVEL =
 type Extra = Record<string | number, unknown>;
 export interface ErrorBoundaryProps {
   children: ReactNode;
-  fallbackUI?: (props: {
-    error: Error | null;
-    resetError: () => void;
-  }) => ReactNode;
+  fallbackUI?: React.ComponentType<{ error: Error | null, resetError: () => void }>;
   errorMessage?: string | (() => string);
   extra?:
     | Extra

--- a/src/error-boundary.js
+++ b/src/error-boundary.js
@@ -11,7 +11,7 @@ export class ErrorBoundary extends Component {
   static contextType = Context;
 
   static propTypes = {
-    fallbackUI: PropTypes.func,
+    fallbackUI: PropTypes.elementType,
     errorMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     extra: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     level: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),


### PR DESCRIPTION
## Description of the change

This updates the type definition for the ErrorBoundary's fallbackUI prop

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes https://github.com/rollbar/rollbar-react/issues/87

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
