### PR TITLE
Standardize eslint and prettier for the entire project with ci checks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,10 @@
+.github
+.next
+build
+bundles
+coverage
+dist
+lib
+node_modules
+out
+public

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,8 +48,8 @@ jobs:
         uses: wearerequired/lint-action@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          prettier: true
-          eslint: true
+          prettier: false
+          eslint: false
           eslint_args: '--max-warnings 0'
           eslint_extensions: js,jsx,ts,tsx
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,27 +1,57 @@
-name: rollbar-react CI
+name: ci
 
 on:
   push:
-    branches: [ '**' ]
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node: [14, 16, 18, 20]
 
     steps:
-    - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm run lint
-    - run: npm run test
+      - name: Set up node ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
+
+      - name: Install library dependencies
+        run: npm ci
+      - name: Install examples/create-react-app dependencies
+        run: cd examples/create-react-app && npm ci
+      - name: Install examples/nextjs dependencies
+        run: cd examples/nextjs && npm ci
+      - name: Install examples/typescript dependencies
+        run: cd examples/typescript && npm ci
+
+      - name: Lint
+        uses: wearerequired/lint-action@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prettier: true
+          eslint: true
+          eslint_args: '--max-warnings 0'
+          eslint_extensions: js,jsx,ts,tsx
+
+      - name: Test
+        run: npm run test

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
       # Setup .npmrc file to publish to GitHub Packages
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
           registry-url: "https://registry.npmjs.org"
           # Defaults to the user or organization that owns the workflow file
           # scope: '@rollbar'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,16 +6,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    # Setup .npmrc file to publish to GitHub Packages
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '12.x'
-        registry-url: 'https://registry.npmjs.org'
-        # Defaults to the user or organization that owns the workflow file
-        # scope: '@rollbar'
-    - run: npm install
-    - run: npm run build
-    - run: npm publish --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
+          # Defaults to the user or organization that owns the workflow file
+          # scope: '@rollbar'
+      - run: npm install
+      - run: npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+.github
+.next
+build
+bundles
+coverage
+dist
+lib
+node_modules
+out
+public

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,38 @@
+{
+  "[github-actions-workflow]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[json5]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file",
+  "editor.tabSize": 2,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "files.trimTrailingWhitespace": true
+}

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -21,6 +21,7 @@
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
+    "root": true,
     "extends": [
       "react-app",
       "react-app/jest"

--- a/examples/nextjs/.eslintrc.json
+++ b/examples/nextjs/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/examples/nextjs/babel.config.js
+++ b/examples/nextjs/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/examples/nextjs/eslint.config.js
+++ b/examples/nextjs/eslint.config.js
@@ -1,0 +1,6 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  root: true,
+  extends: 'next/core-web-vitals',
+  ignorePatterns: ['node_modules'],
+}

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -15,6 +15,7 @@
         "rollbar": "^2.24.0"
       },
       "devDependencies": {
+        "@types/eslint": "^8.56.3",
         "@types/node": "17.0.21",
         "@types/react": "17.0.39",
         "eslint": "8.10.0",
@@ -407,6 +408,28 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.0.tgz",
       "integrity": "sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==",
+      "dev": true
+    },
+    "node_modules/@types/eslint": {
+      "version": "8.56.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.3.tgz",
+      "integrity": "sha512-PvSf1wfv2wJpVIFUMSb+i4PvqNYkB9Rkp9ZDO3oaWzq4SKhsQk4mrMBr3ZH06I0hKrVGLBacmgl8JM4WVjb9dg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "node_modules/@types/json5": {
@@ -3257,6 +3280,28 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.0.tgz",
       "integrity": "sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==",
+      "dev": true
+    },
+    "@types/eslint": {
+      "version": "8.56.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.3.tgz",
+      "integrity": "sha512-PvSf1wfv2wJpVIFUMSb+i4PvqNYkB9Rkp9ZDO3oaWzq4SKhsQk4mrMBr3ZH06I0hKrVGLBacmgl8JM4WVjb9dg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "@types/json5": {

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -16,6 +16,7 @@
     "rollbar": "^2.24.0"
   },
   "devDependencies": {
+    "@types/eslint": "^8.56.3",
     "@types/node": "17.0.21",
     "@types/react": "17.0.39",
     "eslint": "8.10.0",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint src"
   },
   "eslintConfig": {
+    "root": true,
     "extends": [
       "react-app",
       "react-app/jest"

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,9 @@
+/** @type {import('prettier').Config} */
+module.exports = {
+  trailingComma: 'es5',
+  bracketSpacing: true,
+  tabWidth: 2,
+  semi: false,
+  singleQuote: true,
+  arrowParens: 'always',
+};


### PR DESCRIPTION
## Description of the change

This PR opinionatedly declares eslint as the default linter for `rollbar-react`, and prettier the default formatter, as is in Olympus.

The same formatting configuration as Olympus has been used and the build CI has been rewritten with updated actions, caching and a linting step that runs eslint and prettier.

Eslint configuration for each example has been made its own root eslint configuration to avoid grabbing the library's eslint config which defines plugins incompatible with apps.

Eslint ignore file has been added to avoid eslint linting the dist directory, and others.

---

### Linting and format checks are disabled for now, so I can do the linting and formatting on separate PRs to keep the size of them and their reviewability in check.

---

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
