### PR TITLE
Removed formatting rules from eslintrc, leave it to prettier

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -17,13 +17,6 @@ plugins:
   - react
   - react-hooks
   - testing-library
-rules:
-  indent: [error, 2]
-  quotes:
-    - error
-    - single
-    - avoidEscape: true
-      allowTemplateLiterals: true
 settings:
   react:
     version: detect


### PR DESCRIPTION
## Description of the change

We have formatting rules defined in eslintrc, since we've formalized the usage of prettier across the entire project, we can drop these and let prettier handle all things formatting.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
