### PR TITLE
Added build:all and install-all scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Update npm
         run: npm install -g npm@^${{ matrix.npm }}
 
-      - name: Set up cache
+      - name: Cache
         uses: actions/cache@v4
         with:
           path: ~/.npm
@@ -46,14 +46,8 @@ jobs:
             ${{ runner.os }}-node-
             ${{ runner.os }}-
 
-      - name: Install library dependencies
-        run: npm ci
-      - name: Install examples/react-17 dependencies
-        run: cd examples/react-17 && npm ci
-      - name: Install examples/nextjs dependencies
-        run: cd examples/nextjs && npm ci
-      - name: Install examples/typescript dependencies
-        run: cd examples/typescript && npm ci
+      - name: Install
+        run: node scripts/install-all.js ci
 
       - name: Lint
         uses: wearerequired/lint-action@v2
@@ -64,14 +58,23 @@ jobs:
           eslint_args: '--max-warnings 0'
           eslint_extensions: js,jsx,ts,tsx
 
-      - name: Build library
-        run: npm run build
-      - name: Build examples/react-17
-        run: cd examples/react-17 && npm run build
-      - name: Build examples/nextjs
-        run: cd examples/nextjs && npm run build
-      - name: Build examples/typescript
-        run: cd examples/typescript && npm run build
+      - name: Build
+        run: npm run build:all
 
       - name: Test
         run: npm run test
+
+  install:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install
+        run: node scripts/install-all.js

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "rollbar-nextjs",
       "version": "0.1.0",
       "dependencies": {
-        "@rollbar/react": "0.11.2",
+        "@rollbar/react": "^0.11.2",
         "next": "12.1.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",

--- a/examples/react-17/package-lock.json
+++ b/examples/react-17/package-lock.json
@@ -24,6 +24,7 @@
       }
     },
     "../..": {
+      "name": "@rollbar/react",
       "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
@@ -59,6 +60,7 @@
         "eslint-plugin-testing-library": "^6.2.0",
         "fast-check": "^3.15.1",
         "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.2.5",
         "prop-types": "^15.8.1",
         "react": "^17",
@@ -69,6 +71,7 @@
         "rollup": "^4.12.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "ts-jest": "^29.1.2",
+        "ts-node": "^10.9.2",
         "typescript": "^5"
       },
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "rollup": "^4.12.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "ts-jest": "^29.1.2",
+        "ts-node": "^10.9.2",
         "typescript": "^5"
       },
       "peerDependencies": {
@@ -1997,6 +1998,28 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -3846,6 +3869,30 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -4501,6 +4548,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -5352,6 +5405,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -5560,6 +5619,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -12255,6 +12323,49 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -12513,6 +12624,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -12891,6 +13008,15 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "lint": "eslint src babel.config.js index.d.ts",
     "build:clean": "rimraf dist lib bundles",
     "build:files": "rollup --config",
-    "build": "npm run build:clean && npm run build:files"
+    "build": "npm run build:clean && npm run build:files",
+    "build:examples": "ts-node ./scripts/build-examples.ts",
+    "build:all": "npm run build && ts-node ./scripts/build-examples.ts"
   },
   "repository": {
     "type": "git",
@@ -87,6 +89,7 @@
     "rollup": "^4.12.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
     "typescript": "^5"
   },
   "peerDependencies": {

--- a/scripts/build-examples.ts
+++ b/scripts/build-examples.ts
@@ -1,0 +1,16 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const examples = path.join(__dirname, '..', 'examples');
+
+fs.readdirSync(examples)
+  .map((p) => path.join(examples, p))
+  .filter((p) => fs.statSync(p).isDirectory())
+  .forEach((p) => {
+    console.log(`\n\x1b[32mBuilding \x1b[1m${p}\x1b[0m`);
+    execSync('npm run build', {
+      stdio: 'inherit',
+      cwd: p,
+    });
+  });

--- a/scripts/install-all.js
+++ b/scripts/install-all.js
@@ -1,0 +1,20 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const cmd = process.argv.includes('ci') ? 'npm ci' : 'npm install';
+
+const root = path.join(__dirname, '..');
+const examples = path.join(root, 'examples');
+
+fs.readdirSync(examples)
+  .map((p) => path.join(examples, p))
+  .concat(root)
+  .filter((p) => fs.statSync(p).isDirectory())
+  .forEach((p) => {
+    console.log(`\n\x1b[32mInstalling (${cmd}) \x1b[1m${p}\x1b[0m`);
+    execSync(cmd, {
+      stdio: 'inherit',
+      cwd: p,
+    });
+  });


### PR DESCRIPTION
## Description of the change

This PR adds two tiny scripts:
- `build:all` builds the library _and_ taps into a new scripts which iterates through each directory in the examples directory to build every project.
- `./scripts/install-all.ts [ci]` is a script that npm installs/ci the library and iterates through each example and does the same.

The CI workflow has been updated to use this, and a new non-cache job was added to make sure `npm install` doesn't stop working due to a bad `package.json`. See: https://github.com/rollbar/rollbar-react/pull/115.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
