### PR TITLE
Release v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rollbar/react",
-  "version": "0.12.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rollbar/react",
-      "version": "0.12.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "tiny-invariant": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rollbar/react",
-  "version": "0.12.1",
+  "version": "1.0.0",
   "description": "Effortlessly track and debug errors in your React applications with Rollbar. This package includes advanced error tracking features and a set of React-specific enhancements to help you identify and fix issues more quickly.",
   "main": "lib",
   "module": "dist",


### PR DESCRIPTION
## Description of the change

Release v1.0.0 version update.

Includes:
* Allow Rollbar.js 3.x peer dependency, https://github.com/rollbar/rollbar-react/pull/132

Note:
Bumping to 1.x as suggested here: https://github.com/rollbar/rollbar-react/pull/131#pullrequestreview-2630026209

## Type of change

- [x] New release
